### PR TITLE
Add initial project skeleton with sample data and tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Flask 設定
+FLASK_APP=run.py
+FLASK_ENV=development
+
+# Vue 設定
+VITE_API_BASE_URL=http://localhost:5000/api

--- a/README.md
+++ b/README.md
@@ -3,12 +3,14 @@
 1. 概要
 社内でのタスク管理を効率化するために内製するタスク管理アプリケーションです。
 このドキュメントは、開発にあたっての要件定義をまとめたものです。
+
 2. 技術スタック
 本プロジェクトは以下の技術スタックで開発を行います。
 Backend: Python 3.x, Flask
 Frontend: Vue.js, Bootstrap
 Database: (TBD - PostgreSQL, SQLite etc.)
 Deployment: Docker, Docker Compose
+
 3. 要件定義（機能一覧）
 3.1. タスク管理機能
 基本項目
@@ -25,6 +27,7 @@ Deployment: Docker, Docker Compose
 階層構造（親子タスク）
 タスクにサブタスク（子タスク）を複数設定できる。
 階層の深さに制限は設けない（無限に入れ子可能）。
+
 3.2. 表示（ビュー）機能
 リスト表示 (デフォルト)
 タスクを一覧形式で表示する。
@@ -40,6 +43,7 @@ Deployment: Docker, Docker Compose
 <summary>検討外の表示方式</summary>
 看板表示: 視認性の観点から、今回の実装からは除外します。
 </details>
+
 3.3. 通知・連携機能
 リマインド機能
 期限が近づいたタスクについて、ユーザーに通知する。
@@ -48,34 +52,48 @@ Deployment: Docker, Docker Compose
 外部サービス連携 (検討事項)
 Microsoft Outlookの予定表との連携。
 Microsoft Teamsとの連携。
+
 3.4. UI/UX
 レスポンシブデザイン: PCだけでなく、スマートフォンやタブレットなどのモバイルデバイスでも快適に操作できるUIを提供する。
 入力の簡素化: 日々の利用でストレスにならないよう、タスク登録や更新の操作は極力シンプルにする。詳細な実績工数の入力は不要とする。
 ヘルプ機能: 優先度や作業量の定義など、ユーザーが迷いやすい項目にはツールチップで説明を表示する。
+
 4. 開発環境の構築
 本プロジェクトはDockerを使用して環境を構築します。
-リポジトリのクローン
-code
-Bash
+
+### Docker を利用した起動
+```bash
 git clone [repository-url]
 cd task-management-tool
-環境変数ファイルの設定
-.env.example ファイルをコピーして .env ファイルを作成し、必要な環境変数を設定します。
-Dockerコンテナの起動
-code
-Bash
+cp .env.example .env
 docker-compose up -d --build
-アプリケーションへのアクセス
-フロントエンド: http://localhost:8080
-バックエンド API: http://localhost:5000
-(ポート番号は docker-compose.yml の設定に依存します)
+```
+- フロントエンド: http://localhost:8080
+- バックエンド API: http://localhost:5000
+
+### ローカル（Windows）環境での起動
+1. PowerShell を管理者権限なしで開く。
+2. 初回のみ以下のコマンドで依存関係をインストール。
+   ```powershell
+   .\scripts\start_local.ps1 -Install
+   ```
+3. バックエンドとフロントエンドを同時に起動。
+   ```powershell
+   .\scripts\start_local.ps1
+   ```
+   - バックエンド: http://localhost:5000
+   - フロントエンド: http://localhost:8080
+
+### サンプルデータ
+- `backend/tests/data/sample_tasks.json` にテストや UI 検証で利用できるサンプルタスクを同梱しています。
+- `GET /api/tasks` エンドポイントはこのサンプルデータを返却します。
+
 5. ディレクトリ構成（案）
-code
-Code
+```
 .
 ├── backend/          # Flaskバックエンド
 │   ├── app/
-│   ├── migrations/
+│   ├── tests/
 │   ├── Dockerfile
 │   └── requirements.txt
 ├── frontend/         # Vue.jsフロントエンド
@@ -83,6 +101,8 @@ Code
 │   ├── src/
 │   ├── Dockerfile
 │   └── package.json
+├── scripts/          # 起動スクリプト
 ├── docker-compose.yml
 ├── .env.example
 └── README.md
+```

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+
+ENV FLASK_APP=run.py
+EXPOSE 5000
+CMD ["flask", "run", "--host", "0.0.0.0", "--port", "5000"]

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,10 @@
+from flask import Flask
+
+from .routes import api_bp
+
+
+def create_app() -> Flask:
+    """Flask アプリケーションを生成して API Blueprint を登録する。"""
+    app = Flask(__name__)
+    app.register_blueprint(api_bp, url_prefix="/api")
+    return app

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from typing import Any, Dict, List
+
+from flask import Blueprint, jsonify
+
+from .schemas import Task
+
+DATA_PATH = Path(__file__).resolve().parent.parent / "tests" / "data" / "sample_tasks.json"
+
+api_bp = Blueprint("api", __name__)
+
+
+def _load_sample_tasks() -> List[Dict[str, Any]]:
+    if DATA_PATH.exists():
+        return Task.load_many(DATA_PATH)
+    today = date.today()
+    fallback_task = Task(
+        id="fallback",
+        title="サンプルタスク",
+        detail="サンプルデータファイルが存在しません。",
+        assignee="未設定",
+        owner="未設定",
+        start_date=today,
+        due_date=today,
+        status="未着手",
+        priority="中",
+        effort="中",
+        children=[],
+    )
+    return [fallback_task.to_dict()]
+
+
+@api_bp.get("/tasks")
+def list_tasks():
+    """タスクのサンプルデータを返却する。"""
+    return jsonify({"tasks": _load_sample_tasks()})

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+
+@dataclass
+class Task:
+    id: str
+    title: str
+    detail: str
+    assignee: str
+    owner: str
+    start_date: date
+    due_date: date
+    status: str
+    priority: str
+    effort: str
+    children: List["Task"] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "detail": self.detail,
+            "assignee": self.assignee,
+            "owner": self.owner,
+            "start_date": self.start_date.isoformat(),
+            "due_date": self.due_date.isoformat(),
+            "status": self.status,
+            "priority": self.priority,
+            "effort": self.effort,
+            "children": [child.to_dict() for child in self.children],
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "Task":
+        children = [cls.from_dict(child) for child in payload.get("children", [])]
+        return cls(
+            id=str(payload["id"]),
+            title=str(payload["title"]),
+            detail=str(payload.get("detail", "")),
+            assignee=str(payload.get("assignee", "")),
+            owner=str(payload.get("owner", "")),
+            start_date=_parse_date(payload.get("start_date")),
+            due_date=_parse_date(payload.get("due_date")),
+            status=str(payload.get("status", "未着手")),
+            priority=str(payload.get("priority", "中")),
+            effort=str(payload.get("effort", "中")),
+            children=children,
+        )
+
+    @classmethod
+    def load_many(cls, path: Path) -> List[Dict[str, Any]]:
+        import json
+
+        with path.open("r", encoding="utf-8") as fp:
+            raw_tasks: Iterable[Dict[str, Any]] = json.load(fp)
+        return [cls.from_dict(task).to_dict() for task in raw_tasks]
+
+
+def _parse_date(value: Any) -> date:
+    if isinstance(value, date):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, str) and value:
+        return datetime.fromisoformat(value).date()
+    raise ValueError("日付は ISO 8601 形式で指定してください。")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+Flask==2.3.3
+python-dotenv==1.0.1

--- a/backend/run.py
+++ b/backend/run.py
@@ -1,0 +1,6 @@
+from app import create_app
+
+app = create_app()
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/backend/tests/data/sample_tasks.json
+++ b/backend/tests/data/sample_tasks.json
@@ -1,0 +1,55 @@
+[
+  {
+    "id": "task-001",
+    "title": "要件定義書のドラフト作成",
+    "detail": "主要な機能要件と非機能要件を整理する",
+    "assignee": "佐藤",
+    "owner": "田中",
+    "start_date": "2024-04-01",
+    "due_date": "2024-04-05",
+    "status": "作業中",
+    "priority": "高",
+    "effort": "大",
+    "children": [
+      {
+        "id": "task-001-1",
+        "title": "既存業務ヒアリング",
+        "detail": "利用部門とのヒアリング実施",
+        "assignee": "佐藤",
+        "owner": "田中",
+        "start_date": "2024-04-01",
+        "due_date": "2024-04-02",
+        "status": "完了",
+        "priority": "中",
+        "effort": "中",
+        "children": []
+      },
+      {
+        "id": "task-001-2",
+        "title": "要件ドラフト作成",
+        "detail": "ヒアリング内容を整理してドキュメント化",
+        "assignee": "佐藤",
+        "owner": "田中",
+        "start_date": "2024-04-03",
+        "due_date": "2024-04-05",
+        "status": "作業中",
+        "priority": "高",
+        "effort": "大",
+        "children": []
+      }
+    ]
+  },
+  {
+    "id": "task-002",
+    "title": "UI プロトタイプ作成",
+    "detail": "主要画面のワイヤーフレーム作成",
+    "assignee": "鈴木",
+    "owner": "田中",
+    "start_date": "2024-04-06",
+    "due_date": "2024-04-12",
+    "status": "未着手",
+    "priority": "中",
+    "effort": "中",
+    "children": []
+  }
+]

--- a/backend/tests/test_sample_data.py
+++ b/backend/tests/test_sample_data.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+from app.schemas import Task
+
+
+def test_sample_tasks_loadable():
+    data_path = Path(__file__).parent / "data" / "sample_tasks.json"
+    payloads = Task.load_many(data_path)
+    assert isinstance(payloads, list)
+    assert payloads, "サンプルタスクが空です"
+    for task in payloads:
+        assert "id" in task
+        assert "title" in task
+        assert "children" in task

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.9'
+
+services:
+  backend:
+    build: ./backend
+    command: flask run --host 0.0.0.0 --port 5000
+    environment:
+      - FLASK_APP=run.py
+      - FLASK_ENV=development
+    volumes:
+      - ./backend:/app
+    ports:
+      - "5000:5000"
+
+  frontend:
+    build: ./frontend
+    command: npm run dev -- --host
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+    ports:
+      - "8080:8080"
+    depends_on:
+      - backend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:20-alpine
+
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install
+COPY . .
+
+EXPOSE 8080
+CMD ["npm", "run", "dev", "--", "--host"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "todo-app-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "axios": "^1.6.2",
+    "bootstrap": "^5.3.2",
+    "vue": "^3.3.4"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^4.4.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Todo App</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,0 +1,22 @@
+<template>
+  <main class="container py-4">
+    <header class="mb-4">
+      <h1 class="h3">タスク一覧</h1>
+      <p class="text-muted">Flask バックエンドから取得したサンプルタスクを表示します。</p>
+    </header>
+    <TaskList :tasks="tasks" />
+  </main>
+</template>
+
+<script setup>
+import { onMounted, ref } from 'vue'
+import axios from 'axios'
+import TaskList from './components/TaskList.vue'
+
+const tasks = ref([])
+
+onMounted(async () => {
+  const response = await axios.get('/api/tasks')
+  tasks.value = response.data.tasks
+})
+</script>

--- a/frontend/src/components/TaskItem.vue
+++ b/frontend/src/components/TaskItem.vue
@@ -1,0 +1,47 @@
+<template>
+  <div class="list-group-item">
+    <div class="d-flex justify-content-between align-items-center">
+      <div>
+        <strong>{{ task.title }}</strong>
+        <small class="ms-2 text-muted">{{ task.assignee }} / {{ task.owner }}</small>
+      </div>
+      <span class="badge" :class="statusClass">{{ task.status }}</span>
+    </div>
+    <p class="mb-1 text-muted">{{ task.detail }}</p>
+    <ul class="list-inline small mb-0">
+      <li class="list-inline-item">優先度: {{ task.priority }}</li>
+      <li class="list-inline-item">作業量: {{ task.effort }}</li>
+      <li class="list-inline-item">期間: {{ task.start_date }} ~ {{ task.due_date }}</li>
+    </ul>
+    <div v-if="task.children?.length" class="mt-3 ms-3 border-start ps-3">
+      <TaskItem
+        v-for="child in task.children"
+        :key="child.id"
+        :task="child"
+        :level="level + 1"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, defineProps } from 'vue'
+
+const props = defineProps({
+  task: {
+    type: Object,
+    required: true
+  },
+  level: {
+    type: Number,
+    default: 0
+  }
+})
+
+const statusClass = computed(() => {
+  const status = props.task.status
+  if (status === '完了') return 'bg-success'
+  if (status === '作業中') return 'bg-primary'
+  return 'bg-secondary'
+})
+</script>

--- a/frontend/src/components/TaskList.vue
+++ b/frontend/src/components/TaskList.vue
@@ -1,0 +1,23 @@
+<template>
+  <div v-if="tasks.length" class="list-group">
+    <TaskItem
+      v-for="task in tasks"
+      :key="task.id"
+      :task="task"
+      :level="0"
+    />
+  </div>
+  <p v-else class="text-muted">表示できるタスクがありません。</p>
+</template>
+
+<script setup>
+import { defineProps } from 'vue'
+import TaskItem from './TaskItem.vue'
+
+defineProps({
+  tasks: {
+    type: Array,
+    default: () => []
+  }
+})
+</script>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,0 +1,5 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+import 'bootstrap/dist/css/bootstrap.min.css'
+
+createApp(App).mount('#app')

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,22 @@
+import { fileURLToPath, URL } from 'node:url'
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
+  },
+  server: {
+    host: '0.0.0.0',
+    port: 8080,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:5000',
+        changeOrigin: true
+      }
+    }
+  }
+})

--- a/scripts/start_local.ps1
+++ b/scripts/start_local.ps1
@@ -1,0 +1,31 @@
+Param(
+    [switch]$Install
+)
+
+$ErrorActionPreference = 'Stop'
+
+$projectRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$backendPath = Join-Path $projectRoot '..' 'backend'
+$frontendPath = Join-Path $projectRoot '..' 'frontend'
+
+if ($Install) {
+    Write-Host '=== Backend セットアップ ==='
+    python -m venv "$backendPath/.venv"
+    & "$backendPath/.venv/Scripts/pip.exe" install --upgrade pip
+    & "$backendPath/.venv/Scripts/pip.exe" install -r "$backendPath/requirements.txt"
+
+    Write-Host '=== Frontend セットアップ ==='
+    Push-Location $frontendPath
+    npm install
+    Pop-Location
+}
+
+Write-Host '=== Backend 起動 ==='
+Start-Process -FilePath "$backendPath/.venv/Scripts/python.exe" -ArgumentList 'run.py' -WorkingDirectory $backendPath
+
+Start-Sleep -Seconds 3
+
+Write-Host '=== Frontend 起動 ==='
+Push-Location $frontendPath
+npm run dev -- --host
+Pop-Location


### PR DESCRIPTION
## Summary
- scaffold Flask backend that serves sample tasks via /api/tasks and includes JSON fixtures
- scaffold Vue 3 + Vite frontend that consumes the API and displays nested task lists
- add Docker Compose setup, environment template, and Windows PowerShell helper script for local runs

## Testing
- python -m pytest backend/tests/test_sample_data.py

------
https://chatgpt.com/codex/tasks/task_e_68de1eed7fa8832d8b417c8b57811d66