### PR TITLE
Add startup batch script for Windows environments

### DIFF
--- a/startup.bat
+++ b/startup.bat
@@ -1,0 +1,15 @@
+@echo off
+setlocal
+
+set "SCRIPT_DIR=%~dp0"
+set "POWERSHELL_EXE=powershell"
+
+"%POWERSHELL_EXE%" -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT_DIR%scripts\start_local.ps1" %*
+set "EXIT_CODE=%ERRORLEVEL%"
+if not "%EXIT_CODE%"=="0" (
+    echo.
+    echo スクリプトの実行中にエラーが発生しました。上記のメッセージを確認してください。
+    pause
+)
+
+exit /b %EXIT_CODE%


### PR DESCRIPTION
## Summary
- add a Windows startup.bat script at the repository root that delegates to the existing PowerShell launcher
- pause the script when an error occurs so users can review the output

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68de21169600832d9c0ab4c937035fee