### PR TITLE
Fix requirements path resolution in PowerShell script

### DIFF
--- a/scripts/start_local.ps1
+++ b/scripts/start_local.ps1
@@ -25,7 +25,8 @@ if ($Install) {
     }
 
     & $pipPath install --upgrade pip
-    & $pipPath install -r "$backendPath/requirements.txt"
+    $requirementsPath = Join-Path -Path $backendPath -ChildPath 'requirements.txt'
+    & $pipPath install -r $requirementsPath
 
     Write-Host '=== Frontend セットアップ ==='
     Push-Location $frontendPath


### PR DESCRIPTION
## Summary
- ensure the requirements.txt path is resolved via Join-Path to avoid PowerShell parsing errors during installation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de27d88198832d8a33b1cd42a58977