### PR TITLE
Fix PowerShell script encoding for Windows execution

### DIFF
--- a/scripts/start_local.ps1
+++ b/scripts/start_local.ps1
@@ -1,6 +1,10 @@
-Param(
+﻿Param(
     [switch]$Install
 )
+
+[Console]::InputEncoding = [System.Text.Encoding]::UTF8
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$PSDefaultParameterValues['*:Encoding'] = 'utf8'
 
 $ErrorActionPreference = 'Stop'
 


### PR DESCRIPTION
## Summary
- ensure the local startup PowerShell script initializes UTF-8 console encodings to prevent mojibake on Windows
- save the script with a UTF-8 BOM so Windows PowerShell parses the file correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de2a20400c832db047d0af70a6a1b5