### PR TITLE
Add SQLite persistence for tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# SQLite データベースファイル
+*.sqlite3
+*.db
+
+# Python キャッシュ
+__pycache__/
+*.pyc

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -6,7 +6,11 @@ from typing import Optional
 
 from flask import Flask, send_from_directory
 
+from .db import init_db
 from .routes import api_bp
+
+
+SAMPLE_DATA_PATH = Path(__file__).resolve().parent.parent / "tests" / "data" / "sample_tasks.json"
 
 
 def create_app() -> Flask:
@@ -15,6 +19,7 @@ def create_app() -> Flask:
     static_folder = str(frontend_dist) if frontend_dist else None
     app = Flask(__name__, static_folder=static_folder, static_url_path="/")
     app.register_blueprint(api_bp, url_prefix="/api")
+    init_db(sample_data_path=SAMPLE_DATA_PATH)
 
     if frontend_dist:
         _register_frontend_routes(app, frontend_dist)

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+from contextlib import closing
+from datetime import date
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from .schemas import Task
+
+
+def get_database_path() -> Path:
+    """環境変数から SQLite のファイルパスを解決する。"""
+    env_path = os.getenv("TODO_DB_PATH")
+    if env_path:
+        return Path(env_path)
+    return Path(__file__).resolve().parent / "todo.sqlite3"
+
+
+def get_connection() -> sqlite3.Connection:
+    """SQLite への接続を生成する。"""
+    db_path = get_database_path()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS tasks (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    detail TEXT NOT NULL,
+    assignee TEXT NOT NULL,
+    owner TEXT NOT NULL,
+    start_date TEXT NOT NULL,
+    due_date TEXT NOT NULL,
+    status TEXT NOT NULL,
+    priority TEXT NOT NULL,
+    effort TEXT NOT NULL,
+    parent_id TEXT REFERENCES tasks(id)
+);
+"""
+
+
+def init_db(sample_data_path: Optional[Path] = None) -> None:
+    """テーブルを作成し、必要に応じてサンプルデータを投入する。"""
+    with closing(get_connection()) as conn:
+        conn.execute(SCHEMA)
+        conn.commit()
+
+    with closing(get_connection()) as conn:
+        cur = conn.execute("SELECT COUNT(*) FROM tasks")
+        (count,) = cur.fetchone()
+        if count:
+            return
+
+        for task in _load_seed_tasks(sample_data_path):
+            _insert_task(conn, task, parent_id=None)
+        conn.commit()
+
+
+def fetch_tasks() -> List[Dict[str, Any]]:
+    """タスクを親子関係に展開したリストとして取得する。"""
+    with closing(get_connection()) as conn:
+        rows = conn.execute(
+            "SELECT id, title, detail, assignee, owner, start_date, due_date, status, priority, effort, parent_id "
+            "FROM tasks"
+        ).fetchall()
+
+    tasks = {row["id"]: _row_to_task(row) for row in rows}
+    roots: List[Dict[str, Any]] = []
+
+    for row in rows:
+        task = tasks[row["id"]]
+        parent_id = row["parent_id"]
+        if parent_id and parent_id in tasks:
+            tasks[parent_id]["children"].append(task)
+        else:
+            roots.append(task)
+
+    for task in tasks.values():
+        task["children"].sort(key=lambda t: (t["start_date"], t["id"]))
+    roots.sort(key=lambda t: (t["start_date"], t["id"]))
+    return roots
+
+
+def insert_task(task: Task, parent_id: Optional[str] = None) -> None:
+    """タスクを永続化する。子タスクも再帰的に登録する。"""
+    with closing(get_connection()) as conn:
+        _insert_task(conn, task.to_dict(), parent_id=parent_id)
+        conn.commit()
+
+
+def _insert_task(conn: sqlite3.Connection, task_payload: Dict[str, Any], parent_id: Optional[str]) -> None:
+    conn.execute(
+        """
+        INSERT INTO tasks (
+            id, title, detail, assignee, owner, start_date, due_date, status, priority, effort, parent_id
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            task_payload["id"],
+            task_payload["title"],
+            task_payload.get("detail", ""),
+            task_payload.get("assignee", ""),
+            task_payload.get("owner", ""),
+            task_payload.get("start_date"),
+            task_payload.get("due_date"),
+            task_payload.get("status", "未着手"),
+            task_payload.get("priority", "中"),
+            task_payload.get("effort", "中"),
+            parent_id,
+        ),
+    )
+
+    for child in task_payload.get("children", []):
+        _insert_task(conn, child, parent_id=task_payload["id"])
+
+
+def _row_to_task(row: sqlite3.Row) -> Dict[str, Any]:
+    return {
+        "id": row["id"],
+        "title": row["title"],
+        "detail": row["detail"],
+        "assignee": row["assignee"],
+        "owner": row["owner"],
+        "start_date": row["start_date"],
+        "due_date": row["due_date"],
+        "status": row["status"],
+        "priority": row["priority"],
+        "effort": row["effort"],
+        "children": [],
+    }
+
+
+def _load_seed_tasks(sample_data_path: Optional[Path]) -> Iterable[Dict[str, Any]]:
+    if sample_data_path and sample_data_path.exists():
+        return Task.load_many(sample_data_path)
+    return [_fallback_task()]
+
+
+def _fallback_task() -> Dict[str, Any]:
+    today = date.today()
+    fallback = Task(
+        id="fallback",
+        title="サンプルタスク",
+        detail="サンプルデータファイルが存在しません。",
+        assignee="未設定",
+        owner="未設定",
+        start_date=today,
+        due_date=today,
+        status="未着手",
+        priority="中",
+        effort="中",
+        children=[],
+    )
+    return fallback.to_dict()

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,39 +1,14 @@
 from __future__ import annotations
 
-from datetime import date
-from pathlib import Path
-from typing import Any, Dict, List
-
 from flask import Blueprint, jsonify
 
-from .schemas import Task
+from .db import fetch_tasks
 
-DATA_PATH = Path(__file__).resolve().parent.parent / "tests" / "data" / "sample_tasks.json"
 
 api_bp = Blueprint("api", __name__)
 
 
-def _load_sample_tasks() -> List[Dict[str, Any]]:
-    if DATA_PATH.exists():
-        return Task.load_many(DATA_PATH)
-    today = date.today()
-    fallback_task = Task(
-        id="fallback",
-        title="サンプルタスク",
-        detail="サンプルデータファイルが存在しません。",
-        assignee="未設定",
-        owner="未設定",
-        start_date=today,
-        due_date=today,
-        status="未着手",
-        priority="中",
-        effort="中",
-        children=[],
-    )
-    return [fallback_task.to_dict()]
-
-
 @api_bp.get("/tasks")
 def list_tasks():
-    """タスクのサンプルデータを返却する。"""
-    return jsonify({"tasks": _load_sample_tasks()})
+    """永続化されたタスク一覧を返却する。"""
+    return jsonify({"tasks": fetch_tasks()})

--- a/backend/tests/test_db.py
+++ b/backend/tests/test_db.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+from app import db
+
+
+def test_init_db_loads_sample_data(tmp_path, monkeypatch):
+    db_path = tmp_path / "tasks.sqlite3"
+    monkeypatch.setenv("TODO_DB_PATH", str(db_path))
+    importlib.reload(db)
+
+    sample_path = Path(__file__).parent / "data" / "sample_tasks.json"
+    db.init_db(sample_data_path=sample_path)
+
+    tasks = db.fetch_tasks()
+    assert tasks, "初期データのロードに失敗しました"
+    root_ids = {task["id"] for task in tasks}
+    assert "task-001" in root_ids
+    assert "task-002" in root_ids
+
+    parent = next(task for task in tasks if task["id"] == "task-001")
+    child_ids = {child["id"] for child in parent["children"]}
+    assert child_ids == {"task-001-1", "task-001-2"}
+
+
+def test_init_db_uses_fallback_when_sample_missing(tmp_path, monkeypatch):
+    db_path = tmp_path / "fallback.sqlite3"
+    monkeypatch.setenv("TODO_DB_PATH", str(db_path))
+    importlib.reload(db)
+
+    missing_sample = tmp_path / "missing.json"
+    db.init_db(sample_data_path=missing_sample)
+
+    tasks = db.fetch_tasks()
+    assert len(tasks) == 1
+    assert tasks[0]["id"] == "fallback"
+    assert tasks[0]["children"] == []


### PR DESCRIPTION
## Summary
- add a SQLite-backed persistence layer with automatic seeding from sample data
- update the Flask factory to initialize the database and read tasks via the new persistence layer
- add unit tests covering database initialization and fallback seeding

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68de486e2974832d893aa29ed4e9bfd9