### PR TITLE
タスク情報のCRUD APIとUIを実装

### DIFF
--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
-from flask import Blueprint, jsonify
+from uuid import uuid4
 
-from .db import fetch_tasks
+from flask import Blueprint, abort, jsonify, request
+from werkzeug.exceptions import HTTPException
+
+from .db import delete_task, fetch_task, fetch_tasks, insert_task, update_task
+from .schemas import Task
 
 
 api_bp = Blueprint("api", __name__)
@@ -12,3 +16,94 @@ api_bp = Blueprint("api", __name__)
 def list_tasks():
     """永続化されたタスク一覧を返却する。"""
     return jsonify({"tasks": fetch_tasks()})
+
+
+@api_bp.get("/tasks/<task_id>")
+def get_task(task_id: str):
+    """指定したタスクを返却する。"""
+
+    task = fetch_task(task_id)
+    if task is None:
+        abort(404, description="指定されたタスクが見つかりません。")
+    return jsonify({"task": task})
+
+
+@api_bp.post("/tasks")
+def create_task():
+    """タスクを新規作成する。"""
+
+    payload = _get_json_payload()
+    parent_id = _normalize_parent_id(payload.pop("parent_id", None))
+    payload.setdefault("id", str(uuid4()))
+
+    if parent_id:
+        _ensure_parent_exists(parent_id)
+
+    task = _load_task_from_payload(payload)
+    insert_task(task, parent_id=parent_id)
+
+    created = fetch_task(task.id)
+    return jsonify({"task": created}), 201
+
+
+@api_bp.put("/tasks/<task_id>")
+def edit_task(task_id: str):
+    """タスク情報を更新する。"""
+
+    payload = _get_json_payload()
+    parent_id = _normalize_parent_id(payload.pop("parent_id", None))
+
+    if parent_id == task_id:
+        abort(400, description="親タスクに自身を指定することはできません。")
+    if parent_id:
+        _ensure_parent_exists(parent_id)
+
+    payload["id"] = task_id
+    task = _load_task_from_payload(payload)
+
+    if not update_task(task, parent_id=parent_id):
+        abort(404, description="指定されたタスクが見つかりません。")
+
+    updated = fetch_task(task_id)
+    return jsonify({"task": updated})
+
+
+@api_bp.delete("/tasks/<task_id>")
+def remove_task(task_id: str):
+    """タスクを削除する。"""
+
+    if not delete_task(task_id):
+        abort(404, description="指定されたタスクが見つかりません。")
+    return jsonify({"deleted": True})
+
+
+def _get_json_payload() -> dict:
+    payload = request.get_json(silent=True)
+    if not isinstance(payload, dict):
+        abort(400, description="有効な JSON ボディを指定してください。")
+    return payload
+
+
+def _load_task_from_payload(payload: dict) -> Task:
+    try:
+        return Task.from_dict(payload)
+    except (KeyError, ValueError) as exc:
+        abort(400, description=str(exc))
+
+
+def _ensure_parent_exists(parent_id: str) -> None:
+    if fetch_task(parent_id) is None:
+        abort(400, description="指定された親タスクが存在しません。")
+
+
+def _normalize_parent_id(parent_id: object) -> str | None:
+    if parent_id in (None, ""):
+        return None
+    return str(parent_id)
+
+
+@api_bp.errorhandler(HTTPException)
+def _handle_http_exception(exc: HTTPException):
+    response = jsonify({"message": exc.description})
+    response.status_code = exc.code or 500
+    return response

--- a/backend/tests/test_routes.py
+++ b/backend/tests/test_routes.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import importlib
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "api.sqlite3"
+    monkeypatch.setenv("TODO_DB_PATH", str(db_path))
+
+    from app import db as db_module
+    import app as app_package
+
+    importlib.reload(db_module)
+    importlib.reload(app_package)
+
+    sample_path = Path(__file__).parent / "data" / "sample_tasks.json"
+    db_module.init_db(sample_data_path=sample_path)
+
+    app = app_package.create_app()
+    app.config.update(TESTING=True)
+    return app.test_client()
+
+
+def test_task_crud_api(client):
+    today = date.today()
+    payload = {
+        "title": "API登録タスク",
+        "detail": "API経由で登録します",
+        "assignee": "山田",
+        "owner": "佐藤",
+        "start_date": today.isoformat(),
+        "due_date": (today + timedelta(days=5)).isoformat(),
+        "status": "未着手",
+        "priority": "中",
+        "effort": "中",
+    }
+
+    create_resp = client.post("/api/tasks", json=payload)
+    assert create_resp.status_code == 201
+    created = create_resp.get_json()["task"]
+    task_id = created["id"]
+    assert created["title"] == payload["title"]
+    assert created["parent_id"] is None
+
+    list_resp = client.get("/api/tasks")
+    assert list_resp.status_code == 200
+    tasks = list_resp.get_json()["tasks"]
+    assert any(task["id"] == task_id for task in tasks)
+
+    get_resp = client.get(f"/api/tasks/{task_id}")
+    assert get_resp.status_code == 200
+    assert get_resp.get_json()["task"]["id"] == task_id
+
+    update_payload = {
+        **payload,
+        "status": "作業中",
+        "priority": "高",
+        "effort": "大",
+    }
+    update_resp = client.put(f"/api/tasks/{task_id}", json=update_payload)
+    assert update_resp.status_code == 200
+    updated = update_resp.get_json()["task"]
+    assert updated["status"] == "作業中"
+    assert updated["priority"] == "高"
+    assert updated["effort"] == "大"
+
+    delete_resp = client.delete(f"/api/tasks/{task_id}")
+    assert delete_resp.status_code == 200
+    assert delete_resp.get_json()["deleted"] is True
+
+    missing_resp = client.get(f"/api/tasks/{task_id}")
+    assert missing_resp.status_code == 404

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,22 +1,301 @@
 <template>
   <main class="container py-4">
     <header class="mb-4">
-      <h1 class="h3">タスク一覧</h1>
-      <p class="text-muted">Flask バックエンドから取得したサンプルタスクを表示します。</p>
+      <h1 class="h3">タスク管理</h1>
+      <p class="text-muted mb-0">API を通じてタスクの登録・更新・削除が行えます。</p>
     </header>
-    <TaskList :tasks="tasks" />
+
+    <section class="mb-5">
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <h2 class="h5 mb-0">
+          {{ isEditing ? 'タスクを更新' : 'タスクを登録' }}
+          <span v-if="isEditing" class="badge bg-warning text-dark ms-2">編集中</span>
+        </h2>
+        <button
+          type="button"
+          class="btn btn-outline-success btn-sm"
+          @click="resetForm()"
+        >
+          新規タスク
+        </button>
+      </div>
+      <div v-if="errorMessage" class="alert alert-danger" role="alert">
+        {{ errorMessage }}
+      </div>
+      <div
+        v-if="formTask.parent_id"
+        class="alert alert-info d-flex justify-content-between align-items-center"
+        role="alert"
+      >
+        <span>
+          親タスク: <strong>{{ parentTitle || formTask.parent_id }}</strong>
+        </span>
+        <button
+          type="button"
+          class="btn btn-sm btn-outline-light text-dark"
+          @click="resetForm()"
+        >
+          親タスク解除
+        </button>
+      </div>
+      <form class="row g-3" @submit.prevent="handleSubmit">
+        <div class="col-md-6">
+          <label class="form-label">タイトル<span class="text-danger">*</span></label>
+          <input
+            type="text"
+            class="form-control"
+            v-model="formTask.title"
+            required
+          />
+        </div>
+        <div class="col-md-6">
+          <label class="form-label">担当者</label>
+          <input
+            type="text"
+            class="form-control"
+            v-model="formTask.assignee"
+          />
+        </div>
+        <div class="col-md-6">
+          <label class="form-label">責任者</label>
+          <input
+            type="text"
+            class="form-control"
+            v-model="formTask.owner"
+          />
+        </div>
+        <div class="col-12">
+          <label class="form-label">詳細</label>
+          <textarea
+            class="form-control"
+            rows="3"
+            v-model="formTask.detail"
+          ></textarea>
+        </div>
+        <div class="col-md-6">
+          <label class="form-label">開始日<span class="text-danger">*</span></label>
+          <input
+            type="date"
+            class="form-control"
+            v-model="formTask.start_date"
+            required
+          />
+        </div>
+        <div class="col-md-6">
+          <label class="form-label">期限<span class="text-danger">*</span></label>
+          <input
+            type="date"
+            class="form-control"
+            v-model="formTask.due_date"
+            required
+          />
+        </div>
+        <div class="col-md-4">
+          <label class="form-label">ステータス</label>
+          <select class="form-select" v-model="formTask.status">
+            <option value="未着手">未着手</option>
+            <option value="作業中">作業中</option>
+            <option value="完了">完了</option>
+          </select>
+        </div>
+        <div class="col-md-4">
+          <label class="form-label">優先度</label>
+          <select class="form-select" v-model="formTask.priority">
+            <option value="低">低</option>
+            <option value="中">中</option>
+            <option value="高">高</option>
+          </select>
+        </div>
+        <div class="col-md-4">
+          <label class="form-label">作業量</label>
+          <select class="form-select" v-model="formTask.effort">
+            <option value="小">小</option>
+            <option value="中">中</option>
+            <option value="大">大</option>
+          </select>
+        </div>
+        <div class="col-12 d-flex justify-content-end gap-2">
+          <button
+            v-if="isEditing"
+            type="button"
+            class="btn btn-outline-secondary"
+            @click="resetForm()"
+          >
+            キャンセル
+          </button>
+          <button type="submit" class="btn btn-primary">
+            {{ isEditing ? '更新する' : '追加する' }}
+          </button>
+        </div>
+      </form>
+    </section>
+
+    <section>
+      <h2 class="h5 mb-3">タスク一覧</h2>
+      <TaskList
+        :tasks="tasks"
+        @edit="handleEdit"
+        @delete="handleDelete"
+        @add-child="handleAddChild"
+      />
+    </section>
   </main>
 </template>
 
 <script setup>
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, reactive, ref } from 'vue'
 import axios from 'axios'
 import TaskList from './components/TaskList.vue'
 
 const tasks = ref([])
+const isEditing = ref(false)
+const editingId = ref(null)
+const errorMessage = ref('')
+const formTask = reactive(createDefaultTask())
 
-onMounted(async () => {
+function createDefaultTask() {
+  const today = new Date().toISOString().slice(0, 10)
+  return {
+    title: '',
+    detail: '',
+    assignee: '',
+    owner: '',
+    start_date: today,
+    due_date: today,
+    status: '未着手',
+    priority: '中',
+    effort: '中',
+    parent_id: null
+  }
+}
+
+function resetForm(parentId = null) {
+  Object.assign(formTask, createDefaultTask())
+  formTask.parent_id = parentId
+
+  if (parentId) {
+    const parent = findTaskById(tasks.value, parentId)
+    if (parent) {
+      formTask.start_date = parent.start_date
+      formTask.due_date = parent.due_date
+    }
+  }
+
+  isEditing.value = false
+  editingId.value = null
+  errorMessage.value = ''
+}
+
+async function loadTasks() {
   const response = await axios.get('/api/tasks')
   tasks.value = response.data.tasks
+}
+
+onMounted(() => {
+  loadTasks().catch((error) => {
+    errorMessage.value = resolveErrorMessage(error)
+  })
 })
+
+const parentTitle = computed(() => {
+  if (!formTask.parent_id) {
+    return ''
+  }
+  const parent = findTaskById(tasks.value, formTask.parent_id)
+  return parent ? parent.title : ''
+})
+
+async function handleSubmit() {
+  const trimmedTitle = formTask.title.trim()
+  if (!trimmedTitle) {
+    errorMessage.value = 'タイトルを入力してください。'
+    return
+  }
+
+  const payload = {
+    ...formTask,
+    title: trimmedTitle
+  }
+
+  try {
+    if (isEditing.value && editingId.value) {
+      await axios.put(`/api/tasks/${editingId.value}`, payload)
+    } else {
+      await axios.post('/api/tasks', payload)
+    }
+    await loadTasks()
+    resetForm()
+  } catch (error) {
+    errorMessage.value = resolveErrorMessage(error)
+  }
+}
+
+function handleEdit(task) {
+  const defaults = createDefaultTask()
+  isEditing.value = true
+  editingId.value = task.id
+  errorMessage.value = ''
+
+  Object.assign(formTask, {
+    title: task.title ?? defaults.title,
+    detail: task.detail ?? defaults.detail,
+    assignee: task.assignee ?? defaults.assignee,
+    owner: task.owner ?? defaults.owner,
+    start_date: task.start_date ?? defaults.start_date,
+    due_date: task.due_date ?? defaults.due_date,
+    status: task.status ?? defaults.status,
+    priority: task.priority ?? defaults.priority,
+    effort: task.effort ?? defaults.effort,
+    parent_id: task.parent_id ?? null
+  })
+}
+
+async function handleDelete(task) {
+  if (!task?.id) {
+    return
+  }
+
+  if (!window.confirm(`「${task.title}」を削除しますか？`)) {
+    return
+  }
+
+  try {
+    await axios.delete(`/api/tasks/${task.id}`)
+    if (editingId.value === task.id) {
+      resetForm()
+    }
+    await loadTasks()
+  } catch (error) {
+    errorMessage.value = resolveErrorMessage(error)
+  }
+}
+
+function handleAddChild(task) {
+  resetForm(task?.id ?? null)
+}
+
+function findTaskById(list, id) {
+  for (const item of list ?? []) {
+    if (item.id === id) {
+      return item
+    }
+    const found = findTaskById(item.children, id)
+    if (found) {
+      return found
+    }
+  }
+  return null
+}
+
+function resolveErrorMessage(error) {
+  if (error?.response?.data) {
+    if (typeof error.response.data === 'string') {
+      return error.response.data
+    }
+    if (error.response.data.message) {
+      return error.response.data.message
+    }
+  }
+  return '通信中にエラーが発生しました。'
+}
 </script>

--- a/frontend/src/components/TaskItem.vue
+++ b/frontend/src/components/TaskItem.vue
@@ -13,18 +13,44 @@
       <li class="list-inline-item">作業量: {{ task.effort }}</li>
       <li class="list-inline-item">期間: {{ task.start_date }} ~ {{ task.due_date }}</li>
     </ul>
+    <div class="mt-3 d-flex flex-wrap gap-2">
+      <button
+        type="button"
+        class="btn btn-sm btn-outline-primary"
+        @click="emit('edit', task)"
+      >
+        編集
+      </button>
+      <button
+        type="button"
+        class="btn btn-sm btn-outline-secondary"
+        @click="emit('add-child', task)"
+      >
+        子タスク追加
+      </button>
+      <button
+        type="button"
+        class="btn btn-sm btn-outline-danger"
+        @click="emit('delete', task)"
+      >
+        削除
+      </button>
+    </div>
     <div v-if="task.children?.length" class="mt-3 ms-3 border-start ps-3">
       <TaskItem
         v-for="child in task.children"
         :key="child.id"
         :task="child"
+        @edit="emit('edit', $event)"
+        @delete="emit('delete', $event)"
+        @add-child="emit('add-child', $event)"
       />
     </div>
   </div>
 </template>
 
 <script setup>
-import { computed, defineProps } from 'vue'
+import { computed, defineEmits, defineProps } from 'vue'
 
 const props = defineProps({
   task: {
@@ -32,6 +58,8 @@ const props = defineProps({
     required: true
   }
 })
+
+const emit = defineEmits(['edit', 'delete', 'add-child'])
 
 const statusClass = computed(() => {
   const status = props.task.status

--- a/frontend/src/components/TaskList.vue
+++ b/frontend/src/components/TaskList.vue
@@ -4,13 +4,16 @@
       v-for="task in tasks"
       :key="task.id"
       :task="task"
+      @edit="emit('edit', $event)"
+      @delete="emit('delete', $event)"
+      @add-child="emit('add-child', $event)"
     />
   </div>
   <p v-else class="text-muted">表示できるタスクがありません。</p>
 </template>
 
 <script setup>
-import { defineProps } from 'vue'
+import { defineEmits, defineProps } from 'vue'
 import TaskItem from './TaskItem.vue'
 
 defineProps({
@@ -19,4 +22,6 @@ defineProps({
     default: () => []
   }
 })
+
+const emit = defineEmits(['edit', 'delete', 'add-child'])
 </script>


### PR DESCRIPTION
## Summary
- add CRUD endpoints and database helpers for tasks and normalize error responses
- add databaseおよびAPI層のCRUDテストを整備
- implement Vueフォームとリスト連携によるタスクの新規作成・編集・削除UI

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de49eadf34832d84fa061754215113