### PR TITLE
Update Bootstrap CDN references to version 5.3.0

### DIFF
--- a/backend/app/templates/index.html
+++ b/backend/app/templates/index.html
@@ -6,8 +6,8 @@
     <title>タスク管理</title>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
-      integrity="sha384-Vnk7m0G1AA19i0l+xYiV6KU2GKNR3EIBgzHuLlHotE5T7V6czS4EzFIdJIYYdC0J"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+      integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM"
       crossorigin="anonymous"
     />
     <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}" />
@@ -173,8 +173,8 @@
     </div>
 
     <script
-      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-xmI7DiIP9N6byN1Nsx3Rp3XIan+FJxuxMxDPZWS9Vyuk3F7S3Uz7Dnk2a1JpSd2M"
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz"
       crossorigin="anonymous"
       defer
     ></script>


### PR DESCRIPTION
## Summary
- replace the Bootstrap CSS/JS CDN references in the main template with the requested 5.3.0 URLs and integrity hashes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df181dde9c832d85e154cfe6e0871e